### PR TITLE
Enable tsx for Ink tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "clean": "rimraf dist",
     "dev": "pnpm build:node",
-    "quick-test": "pnpm build:node && node tools/quick-test-ink.mjs",
+    "quick-test": "pnpm build:node && tsx tools/quick-test-ink.tsx",
     "quick-test:legacy": "pnpm build:node && node tools/quick-test.js",
     "demo": "pnpm build:node && node examples/repl-adapter-example.js",
     "example": "pnpm build:node && node examples/basic-usage.js",
-    "cli": "pnpm build:node && node tools/cli-ink.mjs",
+    "cli": "pnpm build:node && tsx tools/cli-ink.tsx",
     "cli:legacy": "pnpm build:node && node tools/cli.js",
     "persist": "pnpm build:node && node examples/firmware-persistence.js",
     "prepublishOnly": "pnpm clean && pnpm build && pnpm quick-test"
@@ -72,6 +72,7 @@
     "ink-spinner": "^5.0.0",
     "prettier": "^3.2.0",
     "react": "^19.1.0",
+    "tsx": "^4.7.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@hirossan4049/mpy-sdk",
   "version": "1.0.0",
   "description": "MicroPython SDK for M5Stack devices - Node.js serial communication library",
+  "type": "module",
   "main": "dist/node/index.js",
   "types": "dist/types/index.d.ts",
   "files": [
@@ -12,7 +13,7 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/node/index.js",
+      "import": "./dist/node/index.js",
       "types": "./dist/types/index.d.ts"
     }
   },
@@ -30,7 +31,7 @@
     "quick-test:legacy": "pnpm build:node && node tools/quick-test.js",
     "demo": "pnpm build:node && node examples/repl-adapter-example.js",
     "example": "pnpm build:node && node examples/basic-usage.js",
-    "cli": "pnpm build:node && tsx tools/cli-ink.tsx",
+    "cli": "node --import tsx/esm --no-warnings tools/cli-ink.tsx",
     "cli:legacy": "pnpm build:node && node tools/cli.js",
     "persist": "pnpm build:node && node examples/firmware-persistence.js",
     "prepublishOnly": "pnpm clean && pnpm build && pnpm quick-test"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ devDependencies:
   rimraf:
     specifier: ^5.0.5
     version: 5.0.10
+  tsx:
+    specifier: ^4.7.0
+    version: 4.20.3
   typescript:
     specifier: ^5.3.3
     version: 5.8.3
@@ -53,6 +56,231 @@ packages:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
     dev: true
+
+  /@esbuild/aix-ppc64@0.25.5:
+    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.25.5:
+    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.25.5:
+    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.25.5:
+    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.25.5:
+    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.25.5:
+    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.25.5:
+    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.25.5:
+    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.25.5:
+    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.25.5:
+    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.25.5:
+    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.25.5:
+    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.25.5:
+    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.25.5:
+    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.25.5:
+    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.25.5:
+    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.25.5:
+    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.5:
+    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.25.5:
+    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.5:
+    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.25.5:
+    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.25.5:
+    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.25.5:
+    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.25.5:
+    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.25.5:
+    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@eslint-community/eslint-utils@4.7.0(eslint@8.57.1):
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -642,6 +870,39 @@ packages:
     resolution: {integrity: sha512-uiVjnLem6kkfXumlwUEWEKnwUN5QbSEB0DHy2rNJt0nkYcob5K0TXJ7oJRzhAcvx+SRmz4TahKyN5V9cly/IPA==}
     dev: true
 
+  /esbuild@0.25.5:
+    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.5
+      '@esbuild/android-arm': 0.25.5
+      '@esbuild/android-arm64': 0.25.5
+      '@esbuild/android-x64': 0.25.5
+      '@esbuild/darwin-arm64': 0.25.5
+      '@esbuild/darwin-x64': 0.25.5
+      '@esbuild/freebsd-arm64': 0.25.5
+      '@esbuild/freebsd-x64': 0.25.5
+      '@esbuild/linux-arm': 0.25.5
+      '@esbuild/linux-arm64': 0.25.5
+      '@esbuild/linux-ia32': 0.25.5
+      '@esbuild/linux-loong64': 0.25.5
+      '@esbuild/linux-mips64el': 0.25.5
+      '@esbuild/linux-ppc64': 0.25.5
+      '@esbuild/linux-riscv64': 0.25.5
+      '@esbuild/linux-s390x': 0.25.5
+      '@esbuild/linux-x64': 0.25.5
+      '@esbuild/netbsd-arm64': 0.25.5
+      '@esbuild/netbsd-x64': 0.25.5
+      '@esbuild/openbsd-arm64': 0.25.5
+      '@esbuild/openbsd-x64': 0.25.5
+      '@esbuild/sunos-x64': 0.25.5
+      '@esbuild/win32-arm64': 0.25.5
+      '@esbuild/win32-ia32': 0.25.5
+      '@esbuild/win32-x64': 0.25.5
+    dev: true
+
   /escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -829,9 +1090,23 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
+    dev: true
+
+  /get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /glob-parent@5.1.2:
@@ -1312,6 +1587,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1509,6 +1788,17 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.8.3
+    dev: true
+
+  /tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /type-check@0.4.0:

--- a/tools/cli-ink.tsx
+++ b/tools/cli-ink.tsx
@@ -3,12 +3,9 @@ import React, { useState, useEffect } from 'react';
 import { render, Text, Box, useInput, useApp } from 'ink';
 import SelectInput from 'ink-select-input';
 import Spinner from 'ink-spinner';
-import { createRequire } from 'module';
 import fs from 'fs';
-
-const require = createRequire(import.meta.url);
-const { M5StackClient } = require('../dist/node/index.js');
-const { REPLAdapter } = require('../dist/node/adapters/REPLAdapter.js');
+import { M5StackClient } from '../src/index.js';
+import { REPLAdapter } from '../src/adapters/REPLAdapter.js';
 
 const CLI = () => {
   const { exit } = useApp();

--- a/tools/cli-ink.tsx
+++ b/tools/cli-ink.tsx
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env tsx
 import React, { useState, useEffect } from 'react';
 import { render, Text, Box, useInput, useApp } from 'ink';
 import SelectInput from 'ink-select-input';
@@ -220,46 +220,59 @@ while True:
     }
   });
 
-  return React.createElement(Box, { flexDirection: "column" },
-    React.createElement(Box, { marginBottom: 1 },
-      React.createElement(Text, { bold: true, color: "cyan" }, "🔧 M5Stack SDK CLI")
-    ),
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color="cyan">🔧 M5Stack SDK CLI</Text>
+      </Box>
 
-    message && React.createElement(Box, { marginBottom: 1 },
-      React.createElement(Text, { color: "yellow" }, message)
-    ),
+      {message && (
+        <Box marginBottom={1}>
+          <Text color="yellow">{message}</Text>
+        </Box>
+      )}
 
-    loading && React.createElement(Box, { marginBottom: 1 },
-      React.createElement(Text, { color: "green" },
-        React.createElement(Spinner, { type: "dots" }), " Loading..."
-      )
-    ),
+      {loading && (
+        <Box marginBottom={1}>
+          <Text color="green">
+            <Spinner type="dots" /> Loading...
+          </Text>
+        </Box>
+      )}
 
-    screen === 'menu' && !loading && 
-      React.createElement(SelectInput, { items: mainMenuItems, onSelect: handleMainMenu }),
+      {screen === 'menu' && !loading && (
+        <SelectInput items={mainMenuItems} onSelect={handleMainMenu} />
+      )}
 
-    screen === 'ports' && !loading && React.createElement(Box, { flexDirection: "column" },
-      React.createElement(Box, { marginBottom: 1 },
-        React.createElement(Text, null, "Select a device:")
-      ),
-      React.createElement(SelectInput, { items: ports, onSelect: handlePortSelect })
-    ),
+      {screen === 'ports' && !loading && (
+        <Box flexDirection="column">
+          <Box marginBottom={1}>
+            <Text>Select a device:</Text>
+          </Box>
+          <SelectInput items={ports} onSelect={handlePortSelect} />
+        </Box>
+      )}
 
-    screen === 'connected' && !loading && React.createElement(Box, { flexDirection: "column" },
-      React.createElement(Box, { marginBottom: 1 },
-        React.createElement(Text, { color: "green" }, `✅ Connected to ${selectedPort}`)
-      ),
-      React.createElement(SelectInput, { items: connectedMenuItems, onSelect: handleConnectedMenu })
-    ),
+      {screen === 'connected' && !loading && (
+        <Box flexDirection="column">
+          <Box marginBottom={1}>
+            <Text color="green">✅ Connected to {selectedPort}</Text>
+          </Box>
+          <SelectInput items={connectedMenuItems} onSelect={handleConnectedMenu} />
+        </Box>
+      )}
 
-    commandResult && React.createElement(Box, { marginTop: 1, borderStyle: "single", paddingX: 1 },
-      React.createElement(Text, null, commandResult)
-    ),
+      {commandResult && (
+        <Box marginTop={1} borderStyle="single" paddingX={1}>
+          <Text>{commandResult}</Text>
+        </Box>
+      )}
 
-    React.createElement(Box, { marginTop: 1 },
-      React.createElement(Text, { dimColor: true }, "Press 'q' to quit")
-    )
+      <Box marginTop={1}>
+        <Text dimColor>Press 'q' to quit</Text>
+      </Box>
+    </Box>
   );
 };
 
-render(React.createElement(CLI));
+render(<CLI />);

--- a/tools/quick-test-ink.tsx
+++ b/tools/quick-test-ink.tsx
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env tsx
 import React from 'react';
 import { useState, useEffect } from 'react';
 import { render, Text, Box, useApp } from 'ink';

--- a/tools/quick-test-ink.tsx
+++ b/tools/quick-test-ink.tsx
@@ -1,10 +1,9 @@
 #!/usr/bin/env tsx
-import React from 'react';
-import { useState, useEffect } from 'react';
-import { render, Text, Box, useApp } from 'ink';
+import { Box, render, Text, useApp } from 'ink';
 import SelectInput from 'ink-select-input';
 import Spinner from 'ink-spinner';
 import { createRequire } from 'module';
+import React, { useEffect, useState } from 'react';
 
 const require = createRequire(import.meta.url);
 const { M5StackClient } = require('../dist/node/index.js');
@@ -33,14 +32,14 @@ const QuickTest = () => {
           label: `${port.path} - ${port.manufacturer || 'Unknown'}`,
           value: port.path
         }));
-      
+
       if (portItems.length === 0) {
         portItems.push({ label: '❌ No M5Stack devices found', value: null });
       }
-      
+
       portItems.push({ label: '🔄 Refresh ports', value: 'refresh' });
       portItems.push({ label: '❌ Exit', value: 'exit' });
-      
+
       setPorts(portItems);
     } catch (error) {
       setError(`Error loading ports: ${error.message}`);
@@ -55,9 +54,9 @@ const QuickTest = () => {
   const runTests = async (port) => {
     setPhase('testing');
     setResults([]);
-    
+
     let adapter = null;
-    
+
     try {
       // Test 1: Connection
       addResult('📡', 'Connecting to device...');
@@ -107,7 +106,7 @@ print("Free memory:", gc.mem_free(), "bytes")
 from m5stack import *
 from m5ui import *
 setScreenColor(0x111111)
-title = M5TextBox(10, 10, "Quick Test", lcd.FONT_Default, 0x00FF00, rotate=0)
+title = M5TextBox(10, 10, "Quick Test unko!!!", lcd.FONT_Default, 0x00FF00, rotate=0)
 `);
         addResult('✅', 'M5Stack display initialized');
       } catch (error) {
@@ -141,7 +140,7 @@ while True:
       addResult('✅', 'Persistent app saved to main.py');
 
       addResult('🎉', 'All tests completed successfully!');
-      
+
     } catch (error) {
       addResult('❌', `Error: ${error.message}`, false);
     } finally {
@@ -203,7 +202,7 @@ while True:
               </Text>
             </Box>
           ))}
-          
+
           {phase === 'complete' && (
             <Box marginTop={1}>
               <Text dimColor>Press Ctrl+C to exit</Text>

--- a/tools/tsconfig.esm.json
+++ b/tools/tsconfig.esm.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "ESNext",
     "lib": [
       "ES2022"
     ],
@@ -14,7 +14,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Summary
- rename Ink tool files to `.tsx` and switch to JSX syntax
- update CLI scripts to use `tsx`
- add `tsx` dev dependency
- add tsx shebangs to run tools directly

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686778d84dcc832fbbb24a6f9895680e