### PR TITLE
Add Web Serial API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MicroPython SDK for M5Stack devices - Node.js serial communication library.
 - 🐍 **Python Execution**: Execute Python code and scripts remotely
 - 📊 **Progress Tracking**: Real-time progress updates for file transfers
 - 🔄 **Auto Retry**: Built-in retry logic for reliable communication
+- 🌐 **Browser Ready**: Supports Chrome's Web Serial API for web apps
 - 🧩 **Dependency Analysis**: Analyze Python imports and dependencies
 - 📱 **Cross-OS**: Works on Windows, macOS, and Linux
 
@@ -234,8 +235,11 @@ import { M5StackClient } from '@hirossan4049/mpy-sdk';
 ### Browser (Web Serial API)
 
 ```typescript
-import { M5StackClient } from '@hirossan4049/mpy-sdk/browser';
-// Uses Web Serial API
+import { M5StackClient, WebSerialConnection } from '@hirossan4049/mpy-sdk/browser';
+
+const port = await WebSerialConnection.requestPort();
+const client = new M5StackClient();
+const connection = await client.connect(port);
 ```
 
 ### React Native

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,15 +102,15 @@ class M5StackCLI {
   async listPorts(): Promise<void> {
     const client = new M5StackClient();
     const ports = await client.listPorts();
-    const m5Ports = ports.filter(port => 
+    const m5Ports = ports.filter(port =>
       port.path.includes('usbserial') || port.path.includes('COM')
     );
-    
+
     if (m5Ports.length === 0) {
       console.log('No M5Stack devices found');
       return;
     }
-    
+
     m5Ports.forEach(port => {
       console.log(port.path);
     });
@@ -118,16 +118,16 @@ class M5StackCLI {
 
   private async withConnection<T>(port: string, operation: (adapter: REPLAdapter) => Promise<T>): Promise<T> {
     this.adapter = new REPLAdapter(port);
-    
+
     try {
       await this.adapter.connect();
       await this.adapter.initialize();
-      
+
       const result = await operation(this.adapter);
-      
+
       await this.adapter.disconnect();
       this.adapter = null;
-      
+
       return result;
     } catch (error) {
       if (this.adapter) {
@@ -211,7 +211,7 @@ while True:
         console.error(`Local file not found: ${localFile}`);
         process.exit(1);
       }
-      
+
       const content = fs.readFileSync(localFile, 'utf8');
       await adapter.writeFile(devicePath, content);
     });
@@ -250,7 +250,7 @@ while True:
   async restoreWithConnection(port: string): Promise<void> {
     return this.withConnection(port, async (adapter) => {
       const backupFiles = fs.readdirSync('.').filter(f => f.startsWith('m5stack-backup-') && f.endsWith('.json'));
-      
+
       if (backupFiles.length === 0) {
         console.error('No backup files found');
         process.exit(1);

--- a/src/core/WebSerialConnection.ts
+++ b/src/core/WebSerialConnection.ts
@@ -84,7 +84,7 @@ export class WebSerialConnection extends BaseSerialConnection {
     }
   }
 
-  protected async writeRaw(data: Buffer): Promise<void> {
+  protected async writeRaw(data: Uint8Array): Promise<void> {
     if (!this.writer) {
       throw new CommunicationError('Not connected');
     }

--- a/src/core/WebSerialConnection.ts
+++ b/src/core/WebSerialConnection.ts
@@ -1,0 +1,115 @@
+/**
+ * Browser Web Serial Connection Implementation
+ *
+ * Provides serial communication support using the Web Serial API.
+ */
+
+import { BaseSerialConnection } from './SerialConnection';
+import { CommunicationError, ConnectionOptions, PortInfo } from '../types';
+
+// Minimal interfaces for Web Serial types to avoid depending on lib.dom
+export interface WebSerialPort {
+  open(options: { baudRate: number }): Promise<void>;
+  close(): Promise<void>;
+  readable: ReadableStream<Uint8Array> | null;
+  writable: WritableStream<Uint8Array> | null;
+}
+
+export class WebSerialConnection extends BaseSerialConnection {
+  private serialPort: WebSerialPort | null;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  private writer: WritableStreamDefaultWriter<Uint8Array> | null = null;
+
+  constructor(port: WebSerialPort, options: ConnectionOptions = {}) {
+    super('webserial', options);
+    this.serialPort = port;
+  }
+
+  static isSupported(): boolean {
+    const nav = (globalThis as { navigator?: Record<string, unknown> }).navigator;
+    return typeof nav !== 'undefined' && 'serial' in nav;
+  }
+
+  static async requestPort(): Promise<WebSerialPort> {
+    if (!WebSerialConnection.isSupported()) {
+      throw new CommunicationError('Web Serial API not supported');
+    }
+    return (
+      await (
+        globalThis as unknown as {
+          navigator: { serial: { requestPort: () => Promise<WebSerialPort> } };
+        }
+      ).navigator.serial.requestPort()
+    ) as WebSerialPort;
+  }
+
+  static async listPorts(): Promise<PortInfo[]> {
+    if (!WebSerialConnection.isSupported()) {
+      return [];
+    }
+    const ports = (
+      await (
+        globalThis as unknown as {
+          navigator: { serial: { getPorts: () => Promise<WebSerialPort[]> } };
+        }
+      ).navigator.serial.getPorts()
+    ) as WebSerialPort[];
+    return ports.map((port, i) => ({ path: `webserial-${i}` }));
+  }
+
+  async connect(): Promise<void> {
+    if (!this.serialPort) {
+      throw new CommunicationError('No serial port available');
+    }
+
+    await this.serialPort.open({ baudRate: this.options.baudRate });
+    this.writer = this.serialPort.writable?.getWriter() || null;
+    this.reader = this.serialPort.readable?.getReader() || null;
+    this.onConnected();
+    void this.readLoop();
+  }
+
+  async disconnect(): Promise<void> {
+    try {
+      await this.reader?.cancel();
+      this.reader?.releaseLock();
+      await this.writer?.close();
+      this.writer?.releaseLock();
+      await this.serialPort?.close();
+    } finally {
+      this.reader = null;
+      this.writer = null;
+      this.serialPort = null;
+      this.onDisconnected();
+    }
+  }
+
+  protected async writeRaw(data: Buffer): Promise<void> {
+    if (!this.writer) {
+      throw new CommunicationError('Not connected');
+    }
+    await this.writer.write(data);
+  }
+
+  isOpen(): boolean {
+    return !!this.serialPort && !!this.writer && !!this.reader;
+  }
+
+  private async readLoop(): Promise<void> {
+    if (!this.reader) {
+      return;
+    }
+
+    try {
+      while (this.reader) {
+        const { value, done } = await this.reader.read();
+        if (done) break;
+        if (value) {
+          this.onDataReceived(Buffer.from(value));
+        }
+      }
+    } catch (error) {
+      this.onError(error as Error);
+    }
+  }
+}

--- a/src/core/WebSerialConnection.ts
+++ b/src/core/WebSerialConnection.ts
@@ -105,7 +105,7 @@ export class WebSerialConnection extends BaseSerialConnection {
         const { value, done } = await this.reader.read();
         if (done) break;
         if (value) {
-          this.onDataReceived(Buffer.from(value));
+          this.onDataReceived(value);
         }
       }
     } catch (error) {

--- a/src/core/WebSerialConnection.ts
+++ b/src/core/WebSerialConnection.ts
@@ -4,8 +4,8 @@
  * Provides serial communication support using the Web Serial API.
  */
 
-import { BaseSerialConnection } from './SerialConnection';
 import { CommunicationError, ConnectionOptions, PortInfo } from '../types';
+import { BaseSerialConnection } from './SerialConnection';
 
 // Minimal interfaces for Web Serial types to avoid depending on lib.dom
 export interface WebSerialPort {
@@ -84,7 +84,7 @@ export class WebSerialConnection extends BaseSerialConnection {
     }
   }
 
-  protected async writeRaw(data: Uint8Array): Promise<void> {
+  protected async writeRaw(data: Buffer): Promise<void> {
     if (!this.writer) {
       throw new CommunicationError('Not connected');
     }
@@ -105,7 +105,7 @@ export class WebSerialConnection extends BaseSerialConnection {
         const { value, done } = await this.reader.read();
         if (done) break;
         if (value) {
-          this.onDataReceived(value);
+          this.onDataReceived(Buffer.from(value));
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- implement `WebSerialConnection` using the browser Web Serial API
- add new browser entry point
- export the new connection and update docs

## Testing
- `pnpm build:node`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68679613a7ec832f8a96a53f3ad56c58